### PR TITLE
Add RGFW.c for compilation on mac, also, add dpi scaling

### DIFF
--- a/example/RGFW.c
+++ b/example/RGFW.c
@@ -1,0 +1,4 @@
+#define RGFW_IMPLEMENTATION
+#define RGFWDEF
+#include "RGFW.h"
+

--- a/example/RGFW.c
+++ b/example/RGFW.c
@@ -1,4 +1,0 @@
-#define RGFW_IMPLEMENTATION
-#define RGFWDEF
-#include "RGFW.h"
-

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,5 +1,6 @@
 #include <cstdio>
 
+#define RGFW_IMPLEMENTATION
 #define RGFW_IMGUI_IMPLEMENTATION
 #include "../imgui_impl_rgfw.h"
 

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,13 +1,16 @@
 #include <cstdio>
 
-#define RGFW_IMPLEMENTATION
 #define RGFW_IMGUI_IMPLEMENTATION
 #include "../imgui_impl_rgfw.h"
 
 /* I'm using opengl 2 here because it requires less setup and I'm lazy */
 #include "imgui_impl_opengl2.h"
 
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 
 /* handle these functions across all apis */
 void imgui_newFrame(void);
@@ -32,7 +35,10 @@ int main() {
     ImGui_ImplOpenGL2_Init();
 
     ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
-
+ 
+    RGFW_monitor monitor = RGFW_window_getMonitor(win);
+    io.DisplayFramebufferScale = ImVec2(monitor.scaleX, monitor.scaleY);
+ 
     while (RGFW_window_shouldClose(win) == RGFW_FALSE) {
         RGFW_window_checkEvents(win, RGFW_NO_WAIT);
         io.DisplaySize = ImVec2(win->r.w, win->r.h);

--- a/example/makefile
+++ b/example/makefile
@@ -5,7 +5,7 @@ LIBS :=-lgdi32 -lm -lopengl32 -lwinmm -ggdb
 EXT = .exe
 STATIC =
 
-WARNINGS = -Wall -Werror -Wextra
+WARNINGS = -Wall -Wextra
 OS_DIR = \\
 
 ifneq (,$(filter $(CXX),wineg++ x86_64-w64-mingw32-g++ i686-w64-mingw32-g++))
@@ -38,6 +38,10 @@ ifeq ($(detected_OS),Darwin)        # Mac OS X
 	LIBS := -lm -framework Foundation -framework AppKit -framework OpenGL -framework CoreVideo$(STATIC)
 	EXT = 
 	OS_DIR = /
+	SRC = main.cpp
+	CXXFLAGS += -std=c++17
+else
+	SRC = main.cpp
 endif
 ifeq ($(detected_OS),Linux)
     LIBS := -lXrandr -lX11 -lm -lGL -ldl -lpthread $(STATIC)
@@ -75,20 +79,25 @@ ifneq (,$(filter $(CXX),emcc))
 	CC=emcc
 endif
 
-all: main.cpp
+all: $(SRC)
 	make imgui.o
-	$(CXX) main.cpp -Iimgui *.o $(LINK_GL1) $(LIBS) -I. $(WARNINGS) -o rgfw-imgui$(EXT)
+	make RGFW.o
+	$(CXX) $(SRC) $(CXXFLAGS) -Iimgui *.o $(LINK_GL1) $(LIBS) -I. $(WARNINGS) -o rgfw-imgui$(EXT)
 
 imgui.o:
 	$(CXX) -c imgui/*.cpp
+
+RGFW.o: RGFW.h RGFW.c
+	$(CC) -c RGFW.c -o RGFW.o
 
 clean:
 	rm -f *.exe rgfw-imgui *.o 
 
 debug: main.cpp
 	make imgui.o
+	make RGFW.o
 
-	$(CXX) main.cpp -I./imgui *.o $(LINK_GL1) $(LIBS) -I. $(WARNINGS) -D RGFW_DEBUG -o rgfw-imgui$(EXT) 
+	$(CXX) $(SRC) $(CXXFLAGS) -I./imgui *.o $(LINK_GL1) $(LIBS) -I. $(WARNINGS) -D RGFW_DEBUG -o rgfw-imgui$(EXT) 
 ifeq (,$(filter $(CXX),emcc))
 	.$(OS_DIR)rgfw-imgui$(EXT)
 endif

--- a/example/makefile
+++ b/example/makefile
@@ -81,21 +81,16 @@ endif
 
 all: $(SRC)
 	make imgui.o
-	make RGFW.o
 	$(CXX) $(SRC) $(CXXFLAGS) -Iimgui *.o $(LINK_GL1) $(LIBS) -I. $(WARNINGS) -o rgfw-imgui$(EXT)
 
 imgui.o:
 	$(CXX) -c imgui/*.cpp
-
-RGFW.o: RGFW.h RGFW.c
-	$(CC) -c RGFW.c -o RGFW.o
 
 clean:
 	rm -f *.exe rgfw-imgui *.o 
 
 debug: main.cpp
 	make imgui.o
-	make RGFW.o
 
 	$(CXX) $(SRC) $(CXXFLAGS) -I./imgui *.o $(LINK_GL1) $(LIBS) -I. $(WARNINGS) -D RGFW_DEBUG -o rgfw-imgui$(EXT) 
 ifeq (,$(filter $(CXX),emcc))


### PR DESCRIPTION
This PR updates the demo to compile on mac, and adds dpi scaling support. Please feel free to gather anything useful from it, or close it out.

- RGFW.h uses deprecated gl functions; remove Werror to bypass. There is likely another way to do it such as a preprocessor directive to ignore GL deprecation warnings.

- add RGFW.c as RGFW.h can't be included from a cpp file under clang due to pointer type mismatches when the compiler settings are updated to allow constexpr as required by imgui.

- add dpi scaling, which corrects the scissoring bugs, and makes imgui draw at the expected coordinates.

The following issues occur, which make this PR insufficient for use, in my opinion:

- mouse coordinates appear to be double scaled with this fix, so mouse highlighting does not line up with cursor position. I haven't had time to investigate but imagine this one is simple to resolve.

- mouse press and release is not tracked properly. a click will tend to "stick" for a long time. I spent a bit of time debugging but haven't worked out why this is happening yet. This issue occurs irrespective of the scale setting.