### PR TITLE
Improve key mappings

### DIFF
--- a/imgui_impl_rgfw.h
+++ b/imgui_impl_rgfw.h
@@ -137,89 +137,129 @@ static void ImGui_ImplRgfw_SetClipboardText(void* user_data, const char* text)
 
 static ImGuiKey ImGui_ImplRgfw_KeyToImGuiKey(int key)
 {
-    static const ImGuiKey map[] = {
-        ImGuiKey_None,
-        ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None,
-        ImGuiKey_Backspace,
-        ImGuiKey_Tab,
-        ImGuiKey_Enter,
-        ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None,
-        ImGuiKey_Escape,
-        ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None,
-        ImGuiKey_Space,
-        ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None,
-        ImGuiKey_Apostrophe,
-        ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None,
-        ImGuiKey_Comma,
-        ImGuiKey_Minus,
-        ImGuiKey_Period,
-        ImGuiKey_Slash,
-        ImGuiKey_0, ImGuiKey_1, ImGuiKey_2, ImGuiKey_3, ImGuiKey_4, ImGuiKey_5, ImGuiKey_6, ImGuiKey_7, ImGuiKey_8, ImGuiKey_9,
-        ImGuiKey_None,
-        ImGuiKey_Semicolon,
-        ImGuiKey_None,
-        ImGuiKey_Equal,
-        ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None, ImGuiKey_None,
-        ImGuiKey_Backslash,
-        ImGuiKey_None, ImGuiKey_None, ImGuiKey_None,
-        ImGuiKey_GraveAccent,
-        ImGuiKey_A, ImGuiKey_B, ImGuiKey_C, ImGuiKey_D, ImGuiKey_E, ImGuiKey_F, ImGuiKey_G, ImGuiKey_H, ImGuiKey_I, ImGuiKey_J, ImGuiKey_K, ImGuiKey_L, ImGuiKey_M, ImGuiKey_N, ImGuiKey_O, ImGuiKey_P, ImGuiKey_Q, ImGuiKey_R, ImGuiKey_S, ImGuiKey_T, ImGuiKey_U, ImGuiKey_V, ImGuiKey_W, ImGuiKey_X, ImGuiKey_Y, ImGuiKey_Z,
-        ImGuiKey_LeftBracket,
-        ImGuiKey_None,
-        ImGuiKey_RightBracket,
-        ImGuiKey_None,
-        ImGuiKey_Delete,
-        ImGuiKey_F1,
-        ImGuiKey_F2,
-        ImGuiKey_F3,
-        ImGuiKey_F4,
-        ImGuiKey_F5,
-        ImGuiKey_F6,
-        ImGuiKey_F7,
-        ImGuiKey_F8,
-        ImGuiKey_F9,
-        ImGuiKey_F10,
-        ImGuiKey_F11,
-        ImGuiKey_F12,
-        ImGuiKey_CapsLock,
-        ImGuiKey_LeftShift,
-        ImGuiKey_LeftCtrl,
-        ImGuiKey_LeftAlt,
-        ImGuiKey_LeftSuper,
-        ImGuiKey_RightShift,
-        ImGuiKey_RightCtrl,
-        ImGuiKey_RightAlt,
-        ImGuiKey_RightSuper,
-        ImGuiKey_UpArrow,
-        ImGuiKey_DownArrow,
-        ImGuiKey_LeftArrow,
-        ImGuiKey_RightArrow,
-        ImGuiKey_Insert,
-        ImGuiKey_End,
-        ImGuiKey_Home,
-
-        ImGuiKey_PageUp,
-        ImGuiKey_PageDown,
-        ImGuiKey_NumLock,
-        ImGuiKey_KeypadDivide,
-        ImGuiKey_KeypadMultiply,
-        ImGuiKey_KeypadSubtract,
-        ImGuiKey_Keypad1,
-        ImGuiKey_Keypad2,
-        ImGuiKey_Keypad3,
-        ImGuiKey_Keypad4,
-        ImGuiKey_Keypad5,
-        ImGuiKey_Keypad6,
-        ImGuiKey_Keypad7,
-        ImGuiKey_Keypad8,
-        ImGuiKey_Keypad9,
-        ImGuiKey_Keypad0,
-        ImGuiKey_KeypadDecimal,
-        ImGuiKey_KeypadEnter,
-	ImGuiKey_None
-    };
-
-    return map[key];
+    switch(key) {
+        case RGFW_escape:       return ImGuiKey_Escape;
+        case RGFW_backtick:     return ImGuiKey_GraveAccent;
+        case RGFW_0:            return ImGuiKey_0;
+        case RGFW_1:            return ImGuiKey_1;
+        case RGFW_2:            return ImGuiKey_2;
+        case RGFW_3:            return ImGuiKey_3;
+        case RGFW_4:            return ImGuiKey_4;
+        case RGFW_5:            return ImGuiKey_5;
+        case RGFW_6:            return ImGuiKey_6;
+        case RGFW_7:            return ImGuiKey_7;
+        case RGFW_8:            return ImGuiKey_8;
+        case RGFW_9:            return ImGuiKey_9;
+        case RGFW_minus:        return ImGuiKey_Minus;
+        case RGFW_equals:       return ImGuiKey_Equal;
+        case RGFW_backSpace:    return ImGuiKey_Backspace;
+        case RGFW_tab:          return ImGuiKey_Tab;
+        case RGFW_space:        return ImGuiKey_Space;
+        case RGFW_a:            return ImGuiKey_A;
+        case RGFW_b:            return ImGuiKey_B;
+        case RGFW_c:            return ImGuiKey_C;
+        case RGFW_d:            return ImGuiKey_D;
+        case RGFW_e:            return ImGuiKey_E;
+        case RGFW_f:            return ImGuiKey_F;
+        case RGFW_g:            return ImGuiKey_G;
+        case RGFW_h:            return ImGuiKey_H;
+        case RGFW_i:            return ImGuiKey_I;
+        case RGFW_j:            return ImGuiKey_J;
+        case RGFW_k:            return ImGuiKey_K;
+        case RGFW_l:            return ImGuiKey_L;
+        case RGFW_m:            return ImGuiKey_M;
+        case RGFW_n:            return ImGuiKey_N;
+        case RGFW_o:            return ImGuiKey_O;
+        case RGFW_p:            return ImGuiKey_P;
+        case RGFW_q:            return ImGuiKey_Q;
+        case RGFW_r:            return ImGuiKey_R;
+        case RGFW_s:            return ImGuiKey_S;
+        case RGFW_t:            return ImGuiKey_T;
+        case RGFW_u:            return ImGuiKey_U;
+        case RGFW_v:            return ImGuiKey_V;
+        case RGFW_w:            return ImGuiKey_W;
+        case RGFW_x:            return ImGuiKey_X;
+        case RGFW_y:            return ImGuiKey_Y;
+        case RGFW_z:            return ImGuiKey_Z;
+        case RGFW_period:       return ImGuiKey_Period;
+        case RGFW_comma:        return ImGuiKey_Comma;
+        case RGFW_slash:        return ImGuiKey_Slash;
+        case RGFW_bracket:      return ImGuiKey_LeftBracket;
+        case RGFW_closeBracket: return ImGuiKey_RightBracket;
+        case RGFW_semicolon:    return ImGuiKey_Semicolon;
+        case RGFW_apostrophe:   return ImGuiKey_Apostrophe;
+        case RGFW_backSlash:    return ImGuiKey_Backslash;
+        case RGFW_return:       return ImGuiKey_Enter;  // Same as RGFW_enter
+        case RGFW_delete:       return ImGuiKey_Delete;
+        case RGFW_F1:           return ImGuiKey_F1;
+        case RGFW_F2:           return ImGuiKey_F2;
+        case RGFW_F3:           return ImGuiKey_F3;
+        case RGFW_F4:           return ImGuiKey_F4;
+        case RGFW_F5:           return ImGuiKey_F5;
+        case RGFW_F6:           return ImGuiKey_F6;
+        case RGFW_F7:           return ImGuiKey_F7;
+        case RGFW_F8:           return ImGuiKey_F8;
+        case RGFW_F9:           return ImGuiKey_F9;
+        case RGFW_F10:          return ImGuiKey_F10;
+        case RGFW_F11:          return ImGuiKey_F11;
+        case RGFW_F12:          return ImGuiKey_F12;
+        case RGFW_F13:          return ImGuiKey_F13;
+        case RGFW_F14:          return ImGuiKey_F14;
+        case RGFW_F15:          return ImGuiKey_F15;
+        case RGFW_F16:          return ImGuiKey_F16;
+        case RGFW_F17:          return ImGuiKey_F17;
+        case RGFW_F18:          return ImGuiKey_F18;
+        case RGFW_F19:          return ImGuiKey_F19;
+        case RGFW_F20:          return ImGuiKey_F20;
+        case RGFW_F21:          return ImGuiKey_F21;
+        case RGFW_F22:          return ImGuiKey_F22;
+        case RGFW_F23:          return ImGuiKey_F23;
+        case RGFW_F24:          return ImGuiKey_F24;
+        case RGFW_F25:          return ImGuiKey_None;  // No ImGuiKey_F25
+        case RGFW_capsLock:     return ImGuiKey_CapsLock;
+        case RGFW_shiftL:       return ImGuiKey_LeftShift;
+        case RGFW_controlL:     return ImGuiKey_LeftCtrl;
+        case RGFW_altL:         return ImGuiKey_LeftAlt;
+        case RGFW_superL:       return ImGuiKey_LeftSuper;
+        case RGFW_shiftR:       return ImGuiKey_RightShift;
+        case RGFW_controlR:     return ImGuiKey_RightCtrl;
+        case RGFW_altR:         return ImGuiKey_RightAlt;
+        case RGFW_superR:       return ImGuiKey_RightSuper;
+        case RGFW_up:           return ImGuiKey_UpArrow;
+        case RGFW_down:         return ImGuiKey_DownArrow;
+        case RGFW_left:         return ImGuiKey_LeftArrow;
+        case RGFW_right:        return ImGuiKey_RightArrow;
+        case RGFW_insert:       return ImGuiKey_Insert;
+        case RGFW_menu:         return ImGuiKey_Menu;
+        case RGFW_end:          return ImGuiKey_End;
+        case RGFW_home:         return ImGuiKey_Home;
+        case RGFW_pageUp:       return ImGuiKey_PageUp;
+        case RGFW_pageDown:     return ImGuiKey_PageDown;
+        case RGFW_numLock:      return ImGuiKey_NumLock;
+        case RGFW_kpSlash:      return ImGuiKey_KeypadDivide;
+        case RGFW_kpMultiply:   return ImGuiKey_KeypadMultiply;
+        case RGFW_kpPlus:       return ImGuiKey_KeypadAdd;
+        case RGFW_kpMinus:      return ImGuiKey_KeypadSubtract;
+        case RGFW_kpEqual:      return ImGuiKey_KeypadEqual;
+        case RGFW_kp1:          return ImGuiKey_Keypad1;
+        case RGFW_kp2:          return ImGuiKey_Keypad2;
+        case RGFW_kp3:          return ImGuiKey_Keypad3;
+        case RGFW_kp4:          return ImGuiKey_Keypad4;
+        case RGFW_kp5:          return ImGuiKey_Keypad5;
+        case RGFW_kp6:          return ImGuiKey_Keypad6;
+        case RGFW_kp7:          return ImGuiKey_Keypad7;
+        case RGFW_kp8:          return ImGuiKey_Keypad8;
+        case RGFW_kp9:          return ImGuiKey_Keypad9;
+        case RGFW_kp0:          return ImGuiKey_Keypad0;
+        case RGFW_kpPeriod:     return ImGuiKey_KeypadDecimal;
+        case RGFW_kpReturn:     return ImGuiKey_KeypadEnter;
+        case RGFW_scrollLock:   return ImGuiKey_ScrollLock;
+        case RGFW_printScreen:  return ImGuiKey_PrintScreen;
+        case RGFW_pause:        return ImGuiKey_Pause;
+        case RGFW_world1:       return ImGuiKey_None;  // Not supported
+        case RGFW_world2:       return ImGuiKey_None;  // Not supported
+        default:                return ImGuiKey_None;
+    }
 }
 
 static bool ImGui_ImplRgfw_ShouldChainCallback(RGFW_window* window)


### PR DESCRIPTION
The RGFW key values changed recently which broke some of these mappings.

Using a switch statement lets you change the underlying values without changing the mappings. Any decent compiler will turn this into a jump table / static array so there won't be any performance impact.