### PR TITLE
Make header C compatible

### DIFF
--- a/imgui_impl_rgfw.h
+++ b/imgui_impl_rgfw.h
@@ -44,7 +44,6 @@
 #define RGFW_IMGUI_H
 
 #include <stdbool.h>
-#include <chrono>
 
 typedef struct RGFW_window RGFW_window;
 
@@ -79,6 +78,8 @@ IMGUI_IMPL_API void     ImGui_ImplRgfw_CharCallback(RGFW_window* window, unsigne
 #endif /* ifndef RGFW_IMGUI_H */
 
 #ifdef RGFW_IMGUI_IMPLEMENTATION
+
+#include <chrono>
 
 #define RGFWDEF
 #include "RGFW.h"


### PR DESCRIPTION
This change moves the single cpp dependency (chrono) to beneath `RGFW_IMGUI_IMPLEMENTATION`, making the header fully C compatible. This is necessary e.g. when using imgui with C bindings, and is in line with other backend headers.

Note that chrono is used only in the implementation.