### PR TITLE
Fixing cursor flickering on X11

### DIFF
--- a/imgui_impl_rgfw.h
+++ b/imgui_impl_rgfw.h
@@ -551,7 +551,6 @@ static void ImGui_ImplRgfw_UpdateMouseCursor()
 
 			if (imgui_cursor < (ImGuiMouseCursor)sizeof(imgui_mouse_cursors)) {
             	RGFW_window_setMouseStandard(window, imgui_mouse_cursors[imgui_cursor]);
-            	RGFW_window_showMouse(window, 1);
 			}
         }
     }


### PR DESCRIPTION
Setting the cursor visible in RGFW means setting it to its default. 
The operation on line 553 would be immediately overridden, so that:
- If vsync is enabled in RGFW (swapInterval_OpenGL set true) the default cursor will always be shown.
- If vsync is off, multiple changes will be performed during the rendering of the same frame, making it flicker.

This patch fixes its behaviour assuming that RGFW has proper consistent behaviour of those functions on all platforms. If not it would be a bug for upstream. 